### PR TITLE
Fix syntax bug in block.js

### DIFF
--- a/src/block.js
+++ b/src/block.js
@@ -217,9 +217,7 @@ export const blockAction = (instance, engine, time) => {
         ins.originHypotenuse = Math.sqrt((ins.height ** 2)
           + (ins.outwardOffset ** 2))
         engine.playAudio('rotate')
-            console.log('First block center set to', i.weightX.toFixed(2))
-          console.log('Final center set to', finalCenter.toFixed(2), 'diff from first',
-            (finalCenter - firstCenterDrop).toFixed(2))
+      }
       switch (collision) {
         case 1:
           checkBlockOut(instance, engine)


### PR DESCRIPTION
## Summary
- close `calRotate` function and remove stray debug logs from `src/block.js`

## Testing
- `npm run build` *(fails: digital envelope routines unsupported)*

------
https://chatgpt.com/codex/tasks/task_e_683f8b5d2aa48331a206e77209c994b8