### PR TITLE
Improve drop result control

### DIFF
--- a/src/block.js
+++ b/src/block.js
@@ -114,10 +114,16 @@ export const blockAction = (instance, engine, time) => {
           || (engine.width / 2)
         const successSoFar = engine.getVariable(constant.successCount, 0)
         let target
-        if (successSoFar === 0) {
-          target = firstCenter
+        if (i.serverResult) {
+          if (successSoFar === 0) {
+            target = firstCenter
+          } else {
+            target = getNextBlockCenter(engine)
+          }
         } else {
-          target = getNextBlockCenter(engine)
+          const failOffset = engine.width * 0.25
+          const direction = engine.utils.randomPositiveNegative()
+          target = firstCenter + (failOffset * direction)
         }
         i.dropTarget = target
         console.log(
@@ -136,10 +142,16 @@ export const blockAction = (instance, engine, time) => {
           || (engine.width / 2)
         const successSoFar = engine.getVariable(constant.successCount, 0)
         let target
-        if (successSoFar === 0) {
-          target = firstCenter
+        if (i.serverResult) {
+          if (successSoFar === 0) {
+            target = firstCenter
+          } else {
+            target = getNextBlockCenter(engine)
+          }
         } else {
-          target = getNextBlockCenter(engine)
+          const failOffset = engine.width * 0.25
+          const direction = engine.utils.randomPositiveNegative()
+          target = firstCenter + (failOffset * direction)
         }
         i.dropTarget = target
         console.log('Calculated drop target due to timeout', target.toFixed(2))
@@ -158,7 +170,7 @@ export const blockAction = (instance, engine, time) => {
         }
         if (aligned || alignTimeout) {
 
-          i.dropStartX = i.weightX
+          i.dropStartX = (typeof i.dropTarget !== 'undefined') ? i.dropTarget : i.weightX
           i.dropStartY = i.weightY
           engine.setTimeMovement(constant.hookUpMovement, 300)
           console.log('Alignment reached, starting drop')


### PR DESCRIPTION
## Summary
- compute drop targets based on server response
- force block drop to use the predetermined target
- revert accidental build artifacts

## Testing
- `NODE_OPTIONS=--openssl-legacy-provider npm run build`

------
https://chatgpt.com/codex/tasks/task_e_683f921168048331ae13669055b63a68