### PR TITLE
Fix immediate game over on block miss

### DIFF
--- a/index.html
+++ b/index.html
@@ -458,9 +458,7 @@
         },
         setGameFailed: function (f) {
           $("#score").text(score);
-          if (f >= 3) {
-            setTimeout(overShowOver, 1500);
-          }
+          setTimeout(overShowOver, 1500);
         },
         buildRequest: function () {
           return fetch("/api/build").then(function (r) {


### PR DESCRIPTION
## Summary
- show Game Over when the first block is missed rather than waiting for three fails

## Testing
- `npm run build` *(fails: ERR_OSSL_EVP_UNSUPPORTED)*

------
https://chatgpt.com/codex/tasks/task_e_683fa145663c8331aaf0662459dcaaf8