### PR TITLE
Move buttons to bottom area

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,7 +76,7 @@
         left: 0;
         top: 0;
         right: 0;
-        bottom: 0;
+        bottom: 100px;
         margin: auto;
       }
       a {
@@ -320,6 +320,16 @@
         border-radius: 0.05rem;
         display: none;
       }
+      .bottom-controls {
+        position: fixed;
+        left: 0;
+        bottom: 0;
+        width: 100%;
+        height: 100px;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+      }
       #retry {
         padding: 0.1rem 0.2rem;
         margin: 0.1rem auto 0;
@@ -354,8 +364,7 @@
             id="start"
             src="./assets/main-index-start.png"
             class="start"
-          /><button id="build" class="control-button">Build</button
-          ><button id="cashout" class="control-button">Cashout</button>
+          />
         </div>
       </div>
       <div id="modal" class="modal hide">
@@ -380,10 +389,14 @@
           </div>
         </div>
       </div>
-      <div class="wxShare hide"><img src="./assets/main-share-icon.png" /></div>
-    </div>
-    <script src="./dist/main.js"></script>
-    <script src="./assets/zepto-1.1.6.min.js"></script>
+    <div class="wxShare hide"><img src="./assets/main-share-icon.png" /></div>
+  </div>
+  <div class="bottom-controls">
+    <button id="build" class="control-button">Build</button>
+    <button id="cashout" class="control-button">Cashout</button>
+  </div>
+  <script src="./dist/main.js"></script>
+  <script src="./assets/zepto-1.1.6.min.js"></script>
     <script>
       var domReady,
         loadFinish,
@@ -395,8 +408,9 @@
         successCount;
 
       // init window height and width
+      var bottomSpace = 100;
       var gameWidth = window.innerWidth;
-      var gameHeight = window.innerHeight;
+      var gameHeight = window.innerHeight - bottomSpace;
       var ratio = 1.5;
       if (gameHeight / gameWidth < ratio) {
         gameWidth = Math.ceil(gameHeight / ratio);
@@ -501,7 +515,7 @@
         setTimeout(function () {
           game.playBgm();
         });
-        $("#build, #cashout").appendTo(".content").show();
+        $("#build, #cashout").show();
         indexHide();
         setTimeout(game.start, 400);
       });


### PR DESCRIPTION
## Summary
- add new bottom-controls container
- resize game height to leave 100px space
- place build and cashout buttons in the new bottom area

## Testing
- `npm run build`
- `npm run start` *(fails: Exited with code 3)*

------
https://chatgpt.com/codex/tasks/task_e_68417526d9f88331a1aafe34d0c8721c