### PR TITLE
Expand game area via numeric canvas sizing

### DIFF
--- a/index.html
+++ b/index.html
@@ -409,8 +409,10 @@
 
       // init window height and width
       var bottomSpace = 100;
-      var gameWidth = window.innerWidth;
-      var gameHeight = window.innerHeight - bottomSpace;
+      // expand the game area without CSS scaling
+      var scale = 1.3; // increase area by 30%
+      var gameWidth = window.innerWidth * scale;
+      var gameHeight = (window.innerHeight - bottomSpace) * scale;
       $(".content").css({ height: gameHeight + "px", width: gameWidth + "px" });
       $(".js-modal-content").css({ width: gameWidth + "px" });
 


### PR DESCRIPTION
## Summary
- increase game area by setting scaled numeric width/height for the canvas

## Testing
- `NODE_OPTIONS=--openssl-legacy-provider npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6841788c2c108331bf455c606ca58463