### PR TITLE
Fix width calculation

### DIFF
--- a/index.html
+++ b/index.html
@@ -411,6 +411,10 @@
       var bottomSpace = 100;
       var gameWidth = window.innerWidth;
       var gameHeight = window.innerHeight - bottomSpace;
+      var ratio = 1.5;
+      if (gameHeight / gameWidth < ratio) {
+        gameWidth = Math.ceil(gameHeight / ratio);
+      }
       $(".content").css({ height: gameHeight + "px", width: gameWidth + "px" });
       $(".js-modal-content").css({ width: gameWidth + "px" });
 


### PR DESCRIPTION
## Summary
- restore ratio-based width logic so canvas width scales with height

## Testing
- `NODE_OPTIONS=--openssl-legacy-provider npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68417bd0857c83318ee08c436b0ffb5e