### PR TITLE
Improve bottom panel design

### DIFF
--- a/index.html
+++ b/index.html
@@ -311,6 +311,139 @@
       .font-wenxue {
         font-family: wenxue;
       }
+      .bottom-controls {
+        position: fixed;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background: #12101e;
+        padding: 0.16rem 0.24rem;
+        display: flex;
+        justify-content: space-between;
+        align-items: flex-start;
+        gap: 0.32rem;
+        box-sizing: border-box;
+        font-size: 0.14rem;
+        color: #fff;
+      }
+      .bet-block,
+      .difficulty-block,
+      .action-block {
+        display: flex;
+        flex-direction: column;
+        gap: 0.08rem;
+      }
+      .bet-label,
+      .difficulty-label {
+        display: flex;
+        align-items: center;
+        font-weight: 600;
+        font-size: 0.16rem;
+        color: #fff;
+        gap: 0.04rem;
+      }
+      .bet-input-group {
+        display: flex;
+        align-items: center;
+      }
+      .bet-input {
+        display: flex;
+        align-items: center;
+        background: #201f2f;
+        border: 1px solid #26233a;
+        border-radius: 0.08rem 0 0 0.08rem;
+        padding: 0 0.12rem;
+        gap: 0.04rem;
+      }
+      .bet-input input {
+        width: 1.2rem;
+        background: transparent;
+        border: none;
+        color: #fff;
+        font-size: 0.16rem;
+        outline: none;
+      }
+      .bet-modifiers {
+        display: flex;
+      }
+      .bet-modifier {
+        background: #201f2f;
+        border: 1px solid #26233a;
+        color: #fff;
+        font-weight: 500;
+        padding: 0 0.12rem;
+        font-size: 0.14rem;
+        cursor: pointer;
+      }
+      .bet-modifier:not(:last-child) {
+        border-right: none;
+      }
+      .bet-modifier:first-child {
+        border-radius: 0 0 0 0;
+      }
+      .bet-modifier:last-child {
+        border-radius: 0 0.08rem 0.08rem 0;
+      }
+      .bet-modifier:hover {
+        background: #2a2740;
+      }
+      .difficulty-options {
+        display: flex;
+      }
+      .difficulty-option {
+        flex: 1;
+        background: transparent;
+        border: 1px solid #26233a;
+        color: #aaaabb;
+        font-weight: 500;
+        padding: 0.08rem 0;
+        cursor: pointer;
+        font-size: 0.14rem;
+      }
+      .difficulty-option:not(:last-child) {
+        border-right: none;
+      }
+      .difficulty-option:first-child {
+        border-radius: 0.08rem 0 0 0.08rem;
+      }
+      .difficulty-option:last-child {
+        border-radius: 0 0.08rem 0.08rem 0;
+      }
+      .difficulty-option.selected {
+        background: #6d21a7;
+        color: #fff;
+      }
+      .difficulty-option:hover {
+        background: #2a2740;
+        color: #fff;
+      }
+      .demo-info {
+        display: flex;
+        align-items: center;
+        background: #6d21a7;
+        color: #fff;
+        padding: 0.08rem 0.12rem;
+        border-radius: 0.08rem;
+        font-weight: 500;
+        font-size: 0.14rem;
+        gap: 0.06rem;
+      }
+      .start-button {
+        margin-left: 0.16rem;
+        padding: 0.12rem 0.24rem;
+        font-size: 0.16rem;
+        font-weight: 600;
+        color: #fff;
+        border: none;
+        border-radius: 0.08rem;
+        background-image: linear-gradient(to right, #fbc02d, #ffeb3b);
+        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+        cursor: pointer;
+        transition: box-shadow 0.2s;
+      }
+      .start-button:hover {
+        box-shadow: 0 4px 6px rgba(0, 0, 0, 0.4);
+      }
       .control-button {
         padding: 0.1rem 0.3rem;
         margin: 0.1rem;
@@ -326,51 +459,6 @@
       }
       .control-button:hover {
         transform: translateY(-2px);
-      }
-      .bottom-controls input {
-        padding: 0.1rem 0.2rem;
-        margin: 0.1rem;
-        font-size: 0.2rem;
-        border: none;
-        border-radius: 0.05rem;
-      }
-      .difficulty-buttons {
-        display: flex;
-
-        gap: 0.1rem;
-      }
-      .difficulty-button {
-        padding: 0.1rem 0.3rem;
-        margin: 0.1rem;
-        font-size: 0.2rem;
-        color: #fff;
-        background: linear-gradient(135deg, #868e96, #495057);
-        border: none;
-        border-radius: 0.1rem;
-        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
-        cursor: pointer;
-        transition: transform 0.2s, background 0.2s;
-      }
-      .difficulty-button:hover {
-        transform: translateY(-2px);
-      }
-      .difficulty-button.selected {
-        background: linear-gradient(135deg, #15aabf, #4c6ef5);
-
-      }
-      .bottom-controls {
-        position: fixed;
-        left: 0;
-        bottom: 0;
-        width: 100%;
-        background: rgba(0, 0, 0, 0.6);
-        padding: 0.2rem;
-        box-sizing: border-box;
-        display: flex;
-        flex-wrap: wrap;
-        justify-content: space-around;
-        align-items: center;
-        gap: 0.1rem;
       }
       #retry {
         padding: 0.1rem 0.3rem;
@@ -410,7 +498,7 @@
         </div>
         <div class="action-2">
           <img
-            id="start"
+            id="start-image"
             src="./assets/main-index-start.png"
             class="start"
           />
@@ -441,12 +529,29 @@
     <div class="wxShare hide"><img src="./assets/main-share-icon.png" /></div>
   </div>
   <div class="bottom-controls">
-    <input id="amount-input" type="number" placeholder="Amount" />
-    <div id="difficulty-buttons" class="difficulty-buttons">
-      <button class="difficulty-button selected" data-level="1">Easy</button>
-      <button class="difficulty-button" data-level="2">Medium</button>
-      <button class="difficulty-button" data-level="3">Hard</button>
-      <button class="difficulty-button" data-level="4">Daredevil</button>
+    <div class="bet-block">
+      <div class="bet-label">Bet Amount <span class="bet-icon">💰</span></div>
+      <div class="bet-input-group">
+        <div class="bet-input"><span>$</span><input id="amount-input" type="number" value="0" /></div>
+        <div class="bet-modifiers">
+          <button class="bet-modifier" data-action="half">1/2</button>
+          <button class="bet-modifier" data-action="double">2X</button>
+          <button class="bet-modifier" data-action="max">Max</button>
+        </div>
+      </div>
+    </div>
+    <div class="difficulty-block">
+      <div class="difficulty-label">Difficulty <span class="info-icon">i</span></div>
+      <div id="difficulty-buttons" class="difficulty-options">
+        <button class="difficulty-option" data-level="1">Easy</button>
+        <button class="difficulty-option" data-level="2">Medium</button>
+        <button class="difficulty-option" data-level="3">Hard</button>
+        <button class="difficulty-option selected" data-level="4">Daredevil</button>
+      </div>
+    </div>
+    <div class="action-block">
+      <div class="demo-info"><span class="info-icon">i</span><span>Betting less than $0.01 will enter demo mode</span></div>
+      <button id="start" class="start-button">Start Game</button>
     </div>
     <button id="build" class="control-button">Build</button>
     <button id="cashout" class="control-button">Cashout</button>
@@ -571,12 +676,22 @@
       }
 
       // click event
-      $(".difficulty-button").on("click", function () {
-        $(".difficulty-button").removeClass("selected");
+      $(".difficulty-option").on("click", function () {
+        $(".difficulty-option").removeClass("selected");
         $(this).addClass("selected");
       });
 
-      $("#start").on("click", function () {
+      $(".bet-modifier").on("click", function () {
+        var input = $("#amount-input");
+        var val = parseFloat(input.val()) || 0;
+        var action = $(this).data("action");
+        if (action === "half") val = val / 2;
+        if (action === "double") val = val * 2;
+        if (action === "max") val = 1;
+        input.val(val.toFixed(2));
+      });
+
+      $("#start, #start-image").on("click", function () {
         if (gameStart) return;
         amount = parseFloat($("#amount-input").val()) || 0;
         difficulty = parseFloat($("#difficulty-buttons .selected").data("level")) || 1;


### PR DESCRIPTION
## Summary
- redesign the bottom panel with dark purple theme
- add bet amount modifiers and difficulty selector
- include demo info and Start Game button
- support both old and new start triggers

## Testing
- `npm run build` *(fails: ERR_OSSL_EVP_UNSUPPORTED)*

------
https://chatgpt.com/codex/tasks/task_e_6841b19a26748331a17034dabab349e8