### PR TITLE
Fix stretched images, remove demo info

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,8 @@
         padding: 0;
       }
       img {
-        width: 100%;
+        max-width: 100%;
+        height: auto;
       }
       html {
         background: #fff;
@@ -417,17 +418,6 @@
         background: #2a2740;
         color: #fff;
       }
-      .demo-info {
-        display: flex;
-        align-items: center;
-        background: #6d21a7;
-        color: #fff;
-        padding: 0.08rem 0.12rem;
-        border-radius: 0.08rem;
-        font-weight: 500;
-        font-size: 0.14rem;
-        gap: 0.06rem;
-      }
       .start-button {
         margin-left: 0.16rem;
         padding: 0.12rem 0.24rem;
@@ -550,7 +540,6 @@
       </div>
     </div>
     <div class="action-block">
-      <div class="demo-info"><span class="info-icon">i</span><span>Betting less than $0.01 will enter demo mode</span></div>
       <button id="start" class="start-button">Start Game</button>
     </div>
     <button id="build" class="control-button">Build</button>


### PR DESCRIPTION
## Summary
- remove demo info banner
- stop stretching images by limiting width

## Testing
- `npm run build` *(fails: ERR_OSSL_EVP_UNSUPPORTED)*

------
https://chatgpt.com/codex/tasks/task_e_6841b567af0883318a9552feb78331f2