### PR TITLE
Fix swing animation for initial block

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -43,7 +43,7 @@ export const getSwingBlockVelocity = (engine, time) => {
   let hard
   switch (true) {
     case successCount < 1:
-      hard = 0
+      hard = 1
       break
     case successCount < 10:
       hard = 1


### PR DESCRIPTION
## Summary
- ensure `getSwingBlockVelocity` uses a non-zero speed for the first block

## Testing
- `NODE_OPTIONS=--openssl-legacy-provider npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6841d7a6c43083319e939d5feb4fdce5